### PR TITLE
Fix per-host rate-limiting for Redis and Postgres backends

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.9
     hooks:
       - id: ruff
       - id: ruff-format

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,11 @@
 # History
 
+## 0.10.0 (Unreleased)
+* Fix per-host rate-limiting for Redis and Postgres backends
+* If both `per_host=True` and a `bucket_name` is specified, use `bucket_name` as a bucket prefix
+
 ## 0.9.3 (2026-04-02)
-* Fix compatibility with `RedisBucket`
-* Fix compatibility with `PostgresBucket`
+* Fix bucket initialization for `RedisBucket` and `PostgresBucket`
 * Use built-in support for pickling `Limiter` from pyrate-limiter 4.1.0
 
 ## 0.9.2 (2026-02-27)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ## 0.10.0 (Unreleased)
 * Fix per-host rate-limiting for Redis and Postgres backends
 * If both `per_host=True` and a `bucket_name` is specified, use `bucket_name` as a bucket prefix
+* Add warning if a custom Limiter object is passed with `per_host=True` and no HostBucketFactory
 
 ## 0.9.3 (2026-04-02)
 * Fix bucket initialization for `RedisBucket` and `PostgresBucket`

--- a/README.md
+++ b/README.md
@@ -123,16 +123,20 @@ The following parameters are available for the most common rate limit intervals:
 <!-- TODO: Section explaining burst rate limit -->
 
 ### Advanced Settings
-If you need to define more complex rate limits, you can create a `Limiter` object instead:
+If you need to define more complex rate limits, you can use `Limiter` directly.
+Note that it must be used with `HostBucketFactory` if you want per-host rate-limiting.
+
 ```python
-from pyrate_limiter import Duration, RequestRate, Limiter
-from requests_ratelimiter import LimiterSession
+from pyrate_limiter import Duration, Rate, Limiter
+from requests_ratelimiter import LimiterSession, HostBucketFactory
 
-nanocentury_rate = RequestRate(10, Duration.SECOND * 3.156)
-fortnight_rate = RequestRate(1000, Duration.DAY * 14)
-trimonthly_rate = RequestRate(10000, Duration.MONTH * 3)
-limiter = Limiter(nanocentury_rate, fortnight_rate, trimonthly_rate)
+nanocentury_rate = Rate(10, Duration.SECOND * 3.156)
+fortnight_rate = Rate(1000, Duration.DAY * 14)
+trimonthly_rate = Rate(10000, Duration.DAY * 90)
 
+# This factory object is required for per-host rate-limiting
+factory = HostBucketFactory(rates=[nanocentury_rate, fortnight_rate, trimonthly_rate])
+limiter = Limiter(factory)
 session = LimiterSession(limiter=limiter)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'requests-ratelimiter'
-version = '0.9.3'
+version = '0.10.0'
 description = 'Rate-limiting for the requests library'
 authors = [{name = 'Jordan Cook'}]
 license = 'MIT'

--- a/requests_ratelimiter/buckets.py
+++ b/requests_ratelimiter/buckets.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, Optional, Type
 
 from pyrate_limiter import InMemoryBucket, PostgresBucket, Rate, RedisBucket, SQLiteBucket
@@ -33,44 +34,41 @@ class HostBucketFactory(BucketFactory):
         """Get or create a bucket for the given item name"""
         if item.name not in self.buckets:
             # Create new bucket for this name
-            bucket = self._create_bucket()
+            bucket = self._create_bucket(item.name)
             self.schedule_leak(bucket)
             self.buckets[item.name] = bucket
 
         return self.buckets[item.name]
 
-    def _create_bucket(self) -> AbstractBucket:
-        """Create a new bucket instance with the configured bucket class"""
+    def _create_bucket(self, name: str) -> AbstractBucket:
+        """Create a new bucket instance, and handle per-host naming for each supported backend"""
         if self.bucket_class == InMemoryBucket:
             return InMemoryBucket(self.rates)
         elif self.bucket_class == SQLiteBucket:
-            kwargs = prepare_sqlite_kwargs(self.bucket_init_kwargs, self.bucket_name)
+            kwargs = prepare_sqlite_kwargs(self.bucket_init_kwargs, name)
             return SQLiteBucket.init_from_file(rates=self.rates, **kwargs)
         elif self.bucket_class == RedisBucket:
             kwargs = self.bucket_init_kwargs.copy()
-            bucket_key = kwargs.pop('bucket_key', self.bucket_name or 'default')
             redis = kwargs.pop('redis')
-            return RedisBucket.init(rates=self.rates, redis=redis, bucket_key=bucket_key)
+            bucket_key = kwargs.pop('bucket_key', _sanitize_name(name))
+            return RedisBucket.init(rates=self.rates, redis=redis, bucket_key=bucket_key, **kwargs)
         elif self.bucket_class == PostgresBucket:
             kwargs = self.bucket_init_kwargs.copy()
             pool = kwargs.pop('pool')
-            table = kwargs.pop('table', self.bucket_name or 'default')
+            table = kwargs.pop('table', _sanitize_name(name))
             return PostgresBucket(pool=pool, table=table, rates=self.rates)
         else:
-            # Generic bucket creation - pass rates as first arg
             return self.bucket_class(self.rates, **self.bucket_init_kwargs)
 
     def __getitem__(self, name: str) -> AbstractBucket:
         """Dict-like access for backward compatibility with _fill_bucket() method"""
         if name not in self.buckets:
-            # Create bucket on access
             temp_item = RateItem(name, 0, 1)
             return self.get(temp_item)
         return self.buckets[name]
 
 
 def prepare_sqlite_kwargs(bucket_kwargs: Dict, bucket_name: Optional[str] = None) -> Dict:
-    """Prepare SQLiteBucket kwargs for v4 compatibility"""
     kwargs = bucket_kwargs.copy()
     if 'path' in kwargs:
         kwargs['db_path'] = str(kwargs.pop('path'))
@@ -78,8 +76,12 @@ def prepare_sqlite_kwargs(bucket_kwargs: Dict, bucket_name: Optional[str] = None
     # If bucket_name is specified, use it as the table name to ensure separation
     # This allows multiple sessions with different bucket_names to share a db file
     if bucket_name and 'table' not in kwargs:
-        kwargs['table'] = f'bucket_{bucket_name}'
+        kwargs['table'] = f'bucket_{_sanitize_name(bucket_name)}'
 
     # Filter to only supported parameters for SQLiteBucket.init_from_file
     supported_params = {'table', 'db_path', 'create_new_table', 'use_file_lock'}
     return {k: v for k, v in kwargs.items() if k in supported_params}
+
+
+def _sanitize_name(name: str) -> str:
+    return re.sub(r'[^a-zA-Z0-9_]', '_', name)

--- a/requests_ratelimiter/requests_ratelimiter.py
+++ b/requests_ratelimiter/requests_ratelimiter.py
@@ -101,10 +101,11 @@ class LimiterMixin(MIXIN_BASE):
 
     def _bucket_name(self, request):
         """Get a bucket name for the given request"""
-        if self.bucket_name:
+        if self.per_host:
+            host = urlparse(request.url).netloc
+            return f'{self.bucket_name}:{host}' if self.bucket_name else host
+        elif self.bucket_name:
             return self.bucket_name
-        elif self.per_host:
-            return urlparse(request.url).netloc
         else:
             return self._default_bucket
 
@@ -188,8 +189,9 @@ class LimiterSession(LimiterMixin, Session):
             :py:class:`~pyrate_limiter.buckets.redis_bucket.RedisBucket`
         bucket_kwargs: Bucket backend keyword arguments
         limiter: An existing Limiter object to use instead of the above params
-        per_host: Track request rate limits separately for each host
         limit_statuses: Alternative HTTP status codes that indicate a rate limit was exceeded
+        per_host: Track request rate limits separately for each host
+        bucket_name: Override default bucket name. In per-host mode, this sets the bucket prefix.
     """
 
     __attrs__ = Session.__attrs__ + [

--- a/requests_ratelimiter/requests_ratelimiter.py
+++ b/requests_ratelimiter/requests_ratelimiter.py
@@ -66,6 +66,11 @@ class LimiterMixin(MIXIN_BASE):
         if limiter:
             self.limiter = limiter
             self._custom_limiter = True
+            if per_host and not isinstance(limiter.bucket_factory, HostBucketFactory):
+                logger.warning(
+                    'Custom limiter does not use HostBucketFactory; per-host rate limiting will '
+                    'not work. Use HostBucketFactory to enable per-host rate limiting.'
+                )
         else:
             factory = HostBucketFactory(
                 rates=rates,

--- a/test/test_buckets.py
+++ b/test/test_buckets.py
@@ -52,14 +52,14 @@ def test_separate_buckets_per_name():
 
 
 @pytest.mark.parametrize(
-    'extra_init_kwargs, expected_key',
+    'extra_init_kwargs, identity, expected_key',
     [
-        ({'bucket_key': 'test_bucket'}, 'test_bucket'),
-        ({}, 'default'),
+        ({}, 'api.example.com', 'api_example_com'),
+        ({'bucket_key': 'override'}, 'api.example.com', 'override'),
+        ({}, 'myapp:api.example.com', 'myapp_api_example_com'),
     ],
-    ids=['explicit_key', 'default_key'],
 )
-def test_redis_bucket(extra_init_kwargs, expected_key):
+def test_redis_bucket(extra_init_kwargs, identity, expected_key):
     mock_redis = MagicMock()
     mock_redis.script_load.return_value = 'fake_sha1'
     factory = HostBucketFactory(
@@ -69,7 +69,7 @@ def test_redis_bucket(extra_init_kwargs, expected_key):
     )
 
     with patch.object(RedisBucket, 'init', wraps=RedisBucket.init) as mock_init:
-        factory._create_bucket()
+        factory._create_bucket(identity)
 
     mock_init.assert_called_once_with(
         rates=factory.rates, redis=mock_redis, bucket_key=expected_key
@@ -82,20 +82,19 @@ def _postgres_init_stub(self, pool, table, rates):
 
 
 @pytest.mark.parametrize(
-    'extra_init_kwargs, factory_kwargs, expected_table',
+    'extra_init_kwargs, identity, expected_table',
     [
-        ({'table': 'test_table'}, {}, 'test_table'),
-        ({}, {'bucket_name': 'my_table'}, 'my_table'),
+        ({}, 'api.example.com', 'api_example_com'),
+        ({'table': 'override'}, 'api.example.com', 'override'),
+        ({}, 'myapp:api.example.com', 'myapp_api_example_com'),
     ],
-    ids=['explicit_table', 'default_from_bucket_name'],
 )
-def test_postgres_bucket(extra_init_kwargs, factory_kwargs, expected_table):
+def test_postgres_bucket(extra_init_kwargs, identity, expected_table):
     mock_pool = MagicMock()
     factory = HostBucketFactory(
         rates=[Rate(5, 1000)],
         bucket_class=PostgresBucket,
         bucket_init_kwargs={'pool': mock_pool, **extra_init_kwargs},
-        **factory_kwargs,
     )
 
     with patch.object(
@@ -105,7 +104,7 @@ def test_postgres_bucket(extra_init_kwargs, factory_kwargs, expected_table):
         return_value=None,
         side_effect=_postgres_init_stub,
     ) as mock_init:
-        factory._create_bucket()
+        factory._create_bucket(identity)
 
     _, kwargs = mock_init.call_args
     assert kwargs == {'pool': mock_pool, 'table': expected_table, 'rates': factory.rates}
@@ -119,7 +118,7 @@ def test_generic_bucket_creation():
         rates=[Rate(5, 1000)],
         bucket_class=CustomBucket,
     )
-    bucket = factory._create_bucket()
+    bucket = factory._create_bucket('test_host')
     assert isinstance(bucket, CustomBucket)
 
 

--- a/test/test_requests_ratelimiter.py
+++ b/test/test_requests_ratelimiter.py
@@ -48,7 +48,6 @@ class CustomSession(LimiterMixin, Session):
         lambda: LimiterSession(per_second=5),
         lambda: CustomSession(per_second=5, flag=True),
     ],
-    ids=['LimiterSession', 'CustomSession'],
 )
 def test_rate_limit_enforcement(mock_sleep, session_factory):
     session = mount_mock_adapter(session_factory())
@@ -82,7 +81,7 @@ def test_limiter_adapter(mock_sleep, limiter_adapter_session: tuple) -> None:
 def test_custom_limiter(mock_sleep):
     bucket = InMemoryBucket([Rate(5, Duration.SECOND)])
     limiter = Limiter(bucket)
-    session = get_mock_session(limiter=limiter)
+    session = get_mock_session(limiter=limiter, per_host=False)
 
     for _ in range(5):
         session.get(MOCKED_URL)
@@ -299,7 +298,7 @@ def test_close_before_any_request_and_idempotent():
 def test_fill_bucket_with_custom_limiter(mock_sleep):
     bucket = InMemoryBucket([Rate(5, Duration.SECOND)])
     limiter = Limiter(bucket)
-    session = get_mock_session(limiter=limiter)
+    session = get_mock_session(limiter=limiter, per_host=False)
     session.get(MOCKED_URL_429)
     session.get(MOCKED_URL_429)
     assert mock_sleep.called is True
@@ -335,11 +334,11 @@ def test_custom_bucket_class(mock_sleep):
     session.close()
 
 
-def test_bucket_name_overrides_per_host():
-    session = LimiterSession(per_second=5, bucket_name='fixed', per_host=True)
+def test_bucket_name_prefixes_per_host():
+    session = LimiterSession(per_second=5, bucket_name='myapp', per_host=True)
     req = PreparedRequest()
     req.url = MOCKED_URL
-    assert session._bucket_name(req) == 'fixed'
+    assert session._bucket_name(req) == 'myapp:requests-ratelimiter.com'
 
 
 def test_max_delay_logs_warning(caplog):
@@ -365,7 +364,6 @@ def test_burst_allows_consecutive_requests(mock_sleep):
         (InMemoryBucket, {}),  # InMemoryBucket
         (SQLiteBucket, None),  # SQLiteBucket (will use fixture to provide kwargs)
     ],
-    ids=['in_memory', 'sqlite'],
 )
 def test_pickling(mock_sleep, bucket_class, bucket_kwargs, tmp_path):
     if bucket_class == SQLiteBucket:
@@ -434,18 +432,19 @@ def test_no_rate_limits_no_limiter():
 
 
 @pytest.mark.parametrize(
-    'url, expected_name',
+    'url, bucket_name, expected_name',
     [
-        ('http+mock://example.com/path', 'example.com'),
-        ('http+mock://example.com:8080/path', 'example.com:8080'),
-        ('http+mock://192.168.1.1/path', '192.168.1.1'),
-        ('http+mock://[::1]/path', '[::1]'),
-        ('http+mock://[::1]:8080/path', '[::1]:8080'),
+        ('http+mock://example.com/path', None, 'example.com'),
+        ('http+mock://example.com:8080/path', None, 'example.com:8080'),
+        ('http+mock://192.168.1.1/path', None, '192.168.1.1'),
+        ('http+mock://[::1]/path', None, '[::1]'),
+        ('http+mock://[::1]:8080/path', None, '[::1]:8080'),
+        ('http+mock://example.com/path', 'myapp', 'myapp:example.com'),
     ],
 )
-def test_bucket_name_from_url(url, expected_name):
+def test_bucket_name_from_url(url, bucket_name, expected_name):
     """per_host bucket names are derived from URL netloc, including ports and IPs"""
-    session = LimiterSession(per_second=5, per_host=True)
+    session = LimiterSession(per_second=5, per_host=True, bucket_name=bucket_name)
     req = PreparedRequest()
     req.url = url
     assert session._bucket_name(req) == expected_name
@@ -454,7 +453,7 @@ def test_bucket_name_from_url(url, expected_name):
 def test_custom_limiter_close_does_not_stop_factory():
     bucket = InMemoryBucket([Rate(5, Duration.SECOND)])
     limiter = Limiter(bucket)
-    session = get_mock_session(limiter=limiter)
+    session = get_mock_session(limiter=limiter, per_host=False)
     session.get(MOCKED_URL)
     session.close()
 

--- a/test/test_requests_ratelimiter.py
+++ b/test/test_requests_ratelimiter.py
@@ -18,7 +18,7 @@ from pyrate_limiter import (
 from requests import PreparedRequest, Session
 from requests_cache import CacheMixin
 
-from requests_ratelimiter import LimiterMixin, LimiterSession
+from requests_ratelimiter import HostBucketFactory, LimiterMixin, LimiterSession
 from requests_ratelimiter.requests_ratelimiter import _convert_rate, _get_valid_kwargs
 from test.conftest import (
     MOCKED_URL,
@@ -81,7 +81,7 @@ def test_limiter_adapter(mock_sleep, limiter_adapter_session: tuple) -> None:
 def test_custom_limiter(mock_sleep):
     bucket = InMemoryBucket([Rate(5, Duration.SECOND)])
     limiter = Limiter(bucket)
-    session = get_mock_session(limiter=limiter, per_host=False)
+    session = get_mock_session(limiter=limiter)
 
     for _ in range(5):
         session.get(MOCKED_URL)
@@ -89,6 +89,40 @@ def test_custom_limiter(mock_sleep):
 
     session.get(MOCKED_URL)
     assert mock_sleep.called is True
+
+
+@patch_sleep
+def test_custom_limiter__per_host(mock_sleep):
+    factory = HostBucketFactory(rates=[Rate(5, Duration.SECOND)])
+    limiter = Limiter(factory)
+    session = get_mock_session(limiter=limiter, per_host=True)
+
+    for _ in range(5):
+        session.get(MOCKED_URL)
+    assert mock_sleep.called is False
+
+    # A different host should not be affected
+    session.get(MOCKED_URL_ALT_HOST)
+    assert mock_sleep.called is False
+
+    session.get(MOCKED_URL)
+    assert mock_sleep.called is True
+
+
+@pytest.mark.parametrize(
+    'session_kwargs, expect_warning',
+    [
+        ({'per_host': True}, True),
+        ({'per_host': False}, False),
+    ],
+)
+def test_custom_limiter__per_host_warning(caplog, session_kwargs, expect_warning):
+    """Warn when a custom limiter without HostBucketFactory is used with per_host=True"""
+    bucket = InMemoryBucket([Rate(5, Duration.SECOND)])
+    limiter = Limiter(bucket)
+    with caplog.at_level('WARNING', logger='requests_ratelimiter'):
+        LimiterSession(limiter=limiter, **session_kwargs)
+    assert ('HostBucketFactory' in caplog.text) == expect_warning
 
 
 @patch_sleep

--- a/uv.lock
+++ b/uv.lock
@@ -653,11 +653,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -705,7 +705,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -716,9 +716,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -750,15 +750,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.2.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/88/815e53084c5079a59df912825a279f41dd2e0df82281770eadc732f5352c/python_discovery-1.2.1.tar.gz", hash = "sha256:180c4d114bff1c32462537eac5d6a332b768242b76b69c0259c7d14b1b680c9e", size = 58457, upload-time = "2026-03-26T22:30:44.496Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl", hash = "sha256:b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502", size = 31674, upload-time = "2026-03-26T22:30:43.396Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
 ]
 
 [[package]]
@@ -871,7 +871,7 @@ wheels = [
 
 [[package]]
 name = "requests-ratelimiter"
-version = "0.9.3"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyrate-limiter" },


### PR DESCRIPTION
* And more generally, `bucket_name` should only be used as a prefix in per-host mode.
* Add warning if a custom `Limiter` object is passed with `per_host=True` and no `HostBucketFactory`

Updates #147